### PR TITLE
Add initial icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# plotly-icons
+
+> Icon set used with Plotly
+
+## Usage
+
+* Install the module with `npm install` or `yarn install`.
+* Import into your project like so: `import {CarretDownIcon} from
+  'plotly-icons';`
+* Add extra classes by adding a className to the imported icon.
+
+## See also
+
+* [mdi-react](https://github.com/levrik/mdi-react)
+* [plotly branding documentation](https://brand.plot.ly/)
+
+## License
+
+&copy; 2017 Plotly, Inc. MIT License.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,17 @@
+import AngleDownIcon from "mdi-react/ChevronDownIcon";
+import CarretDownIcon from "mdi-react/MenuDownIcon";
+import CarretUpIcon from "mdi-react/MenuUpIcon";
+import CloseIcon from "mdi-react/CloseIcon";
+import CogIcon from "mdi-react/SettingsIcon";
+import LinkIcon from "mdi-react/LinkVariantIcon";
+import QuestionIcon from "mdi-react/HelpCircleIcon";
+
+export {
+  AngleDownIcon,
+  CarretDownIcon,
+  CarretUpIcon,
+  CloseIcon,
+  CogIcon,
+  LinkIcon,
+  QuestionIcon
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "plotly-icons",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "mdi-react": {
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/mdi-react/-/mdi-react-2.1.19.tgz",
+      "integrity": "sha1-qgXz6+Swc1eMYN36MKjsfrNoc7c="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "bugs": {
     "url": "https://github.com/plotly/plotly-icons/issues"
   },
-  "homepage": "https://github.com/plotly/plotly-icons#readme"
+  "homepage": "https://github.com/plotly/plotly-icons#readme",
+  "dependencies": {
+    "mdi-react": "^2.1.19"
+  }
 }


### PR DESCRIPTION
Here's what these Icons look like in the editor:

![screen shot 2017-12-29 at 3 41 51 pm](https://user-images.githubusercontent.com/4257572/34447262-3e9a6e46-ecb0-11e7-9a34-eff64aba1b34.png)

![screen shot 2017-12-29 at 3 42 20 pm](https://user-images.githubusercontent.com/4257572/34447259-3b8c5f48-ecb0-11e7-979f-3e1732fa2d32.png)

@aulneau what do you think?
Also, I've been thinking about what you said about giving users a hint on where to use these icons, I think part of that is done with the icons names, we can make them more descriptive to suit plotly's use of these icons vs `mdi`. I also kept more of a reference to the names of icons we've currently got in streambed and editor vs what `mdi` has.

Alright let me know what you think.
Making a pr against `react-plotly.js-editor` now too with these icons, but first I've got to push these up to npm with your review.

cc @bpostlethwaite 