### PR TITLE
Fix package.json for consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
     "url": "https://github.com/plotly/plotly-icons/issues"
   },
   "dependencies": {
-    "mdi-react": "^2.1.19",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "mdi-react": "^2.1.19"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",
@@ -18,7 +16,13 @@
     "babel-preset-react": "^6.11.1",
     "fs": "0.0.1-security",
     "mkdirp": "^0.5.1",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "rimraf": "^2.6.1"
+  },
+  "peerDependencies": {
+    "react": ">15",
+    "react-dom": ">15"
   },
   "homepage": "https://github.com/plotly/plotly-icons#readme",
   "license": "ISC",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1397,7 +1397,7 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.2.0:
+react-dom@^16.0.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
   dependencies:
@@ -1406,7 +1406,7 @@ react-dom@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react@^16.2.0:
+react@^16.0.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:


### PR DESCRIPTION
This moves react and react-dom from dependencies to peerDependencies and devDependencies. This prevents multiple copies of react from being loaded by consumer apps. 

The same needs to be done for react-plotly.js-editor: https://github.com/plotly/react-plotly.js-editor/pull/365